### PR TITLE
Stop Sound Before Dropping Music Disc

### DIFF
--- a/Common/src/main/java/com/williambl/portablejukebox/jukebox/PortableJukeboxItem.java
+++ b/Common/src/main/java/com/williambl/portablejukebox/jukebox/PortableJukeboxItem.java
@@ -40,14 +40,14 @@ public class PortableJukeboxItem extends Item {
         }
 
         if (player.isCrouching()) {
+            if (!world.isClientSide()) {
+                Services.MESSAGES.sendMessage(PortableJukeboxMessage.stop(player, DiscHelper.getSoundEvent(discStack)), player);
+            }
+
             this.setDiscStack(stack, ItemStack.EMPTY);
 
             if (!player.addItem(discStack)) {
                 player.drop(discStack, true);
-            }
-
-            if (!world.isClientSide()) {
-                Services.MESSAGES.sendMessage(PortableJukeboxMessage.stop(player, DiscHelper.getSoundEvent(discStack)), player);
             }
 
             return InteractionResultHolder.success(stack);


### PR DESCRIPTION
Closes #5 

When dropping the music disc from the stack, since the stack is mutable, the disc no longer exists when attempting to stop the sound. To address this, the sound was stopped immediately. Another solution would be to make a deep copy of the stack, but since the stack isn't used for anything else, it's more efficient to simply stop the sound before setting the additional information.